### PR TITLE
fix CVEs

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -83,7 +83,7 @@
                         <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
-					<!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
+		    <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -38,8 +38,10 @@
     <properties>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
-        <asciidoctor.maven.plugin.version>2.2.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
+        <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>2.5.10</asciidoctorj.version>
+        <asciidoctorj.pdf.version>2.3.9</asciidoctorj.pdf.version>
+        <jruby.version>9.4.3.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
@@ -75,6 +77,18 @@
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <version>${asciidoctor.maven.plugin.version}</version>
                 <dependencies>
+                    <!-- Comment this section to use the default jruby artifact provided by the plugin -->
+                    <dependency>
+                        <groupId>org.jruby</groupId>
+                        <artifactId>jruby</artifactId>
+                        <version>${jruby.version}</version>
+                    </dependency>
+					<!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj</artifactId>
+                        <version>${asciidoctorj.version}</version>
+                    </dependency>
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-pdf</artifactId>


### PR DESCRIPTION
This PR is inteded to fix AsciiDoctor related CVEs as mentioned in [Bugzilla](https://bugs.eclipse.org/bugs/show_bug.cgi?id=581580) and #117 :

- CVE-2022-24823
- CVE-2021-43797
- CVE-2021-29425
- CVE-2021-21290

@m0mus, please review and merge, if accepted.